### PR TITLE
Added self-destructing logic!

### DIFF
--- a/src/main/scala/com/archmage/drones/components/Geo.scala
+++ b/src/main/scala/com/archmage/drones/components/Geo.scala
@@ -1,3 +1,5 @@
 package com.archmage.drones.components
 
-final case class Geo(xpos: Int = 0, ypos: Int = 0, xvel: Int = 0, yvel: Int = 0)
+final case class Geo(xpos: Int = 0, ypos: Int = 0, xvel: Int = 0, yvel: Int = 0) {
+  def novel: Geo = Geo(xpos, ypos)
+}

--- a/src/test/scala/com/archmage/drones/DroneSpec.scala
+++ b/src/test/scala/com/archmage/drones/DroneSpec.scala
@@ -53,6 +53,17 @@ class DroneSpec extends FlatSpec {
     assert((drone1.scrap, drone2.scrap) == (startingScrap / 2 + 1, startingScrap / 2))
   }
 
+  "A large number of drones gathering the same structure" should "salvage the correct amount of scrap" in {
+    val startingScrap = 7
+    val drones = List.fill(20)(Drone(Geo(), State[DroneState](Gather())))
+    val structure = Structure(Geo(), startingScrap)
+    var world = World(drones, Seq(structure))
+    world = world.process()
+    val dronesWithScrap = world.drones.count((d) => d.scrap > 0)
+    val dronesWithoutScrap = world.drones.count((d) => d.scrap <= 0)
+    assert((dronesWithScrap, dronesWithoutScrap) == (startingScrap, drones.length - startingScrap))
+  }
+
   "A drone that fails to gather" should "become idle" in {
     val drone = Drone(Geo(), State[DroneState](Gather()))
     var world = World(Seq(drone)) // drone will fail to gather due to no structure present

--- a/src/test/scala/com/archmage/drones/DroneSpec.scala
+++ b/src/test/scala/com/archmage/drones/DroneSpec.scala
@@ -11,8 +11,7 @@ class DroneSpec extends FlatSpec {
     assert(world.drones.head.geo == Geo())
   }
 
-  "A drone with a move target" should "move to that target at a rate of up to 1 horizontal" +
-    " and one vertical space per turn" in {
+  "A drone with a move target" should "move to that target at a rate of up to 1 per axis per turn" in {
     val target = Geo(10, 10)
     val drone = Drone(Geo(), State[DroneState](Move(target.xpos, target.ypos)))
     var world = World(Seq(drone))

--- a/src/test/scala/com/archmage/drones/StructureSpec.scala
+++ b/src/test/scala/com/archmage/drones/StructureSpec.scala
@@ -14,4 +14,10 @@ class StructureSpec extends FlatSpec {
     for(_ <- 1 to gatherCount) world = world.process()
     assert(world.structures.head.scrap == startingScrap - gatherCount)
   }
+
+  "A scrapless structure being gathered" should "not drop below zero scrap" in {
+    var world = World(Seq(Drone(Geo(), State[DroneState](Gather()))), Seq(Structure()))
+    world = world.process()
+    assert(world.structures.head.scrap == 0)
+  }
 }


### PR DESCRIPTION
Drones can now be marked as "self-destructing", which will cause them to explode into a wonderful shower of scrap after a short number of turns. This creates a structure at their location if one does not exist, and adds scrap to a location if it does. It also drops all the scrap the drone was carrying.

Eventually this may have more uses, but for now, that's it!